### PR TITLE
Hardcode python2.7 shebang

### DIFF
--- a/Wifite.py
+++ b/Wifite.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from py.Configuration import Configuration
 from py.Scanner import Scanner

--- a/py/Aircrack.py
+++ b/py/Aircrack.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Process import Process
 from Configuration import Configuration

--- a/py/Aireplay.py
+++ b/py/Aireplay.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Configuration import Configuration
 from Process import Process

--- a/py/Airmon.py
+++ b/py/Airmon.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Interface import Interface
 from Process import Process

--- a/py/Airodump.py
+++ b/py/Airodump.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Process import Process
 from Configuration import Configuration

--- a/py/Arguments.py
+++ b/py/Arguments.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 import argparse
 from Color import Color

--- a/py/Attack.py
+++ b/py/Attack.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 import time
 

--- a/py/AttackWEP.py
+++ b/py/AttackWEP.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Attack import Attack
 from Airodump import Airodump

--- a/py/AttackWPA.py
+++ b/py/AttackWPA.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Attack import Attack
 from Airodump import Airodump

--- a/py/AttackWPS.py
+++ b/py/AttackWPS.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Attack import Attack
 from Color import Color

--- a/py/Client.py
+++ b/py/Client.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 class Client(object):
     '''

--- a/py/Color.py
+++ b/py/Color.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 import sys
 

--- a/py/Configuration.py
+++ b/py/Configuration.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 

--- a/py/CrackResult.py
+++ b/py/CrackResult.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 

--- a/py/CrackResultWEP.py
+++ b/py/CrackResultWEP.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 from CrackResult import CrackResult

--- a/py/CrackResultWPA.py
+++ b/py/CrackResultWPA.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 from CrackResult import CrackResult

--- a/py/CrackResultWPS.py
+++ b/py/CrackResultWPS.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 from CrackResult import CrackResult

--- a/py/Handshake.py
+++ b/py/Handshake.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Process import Process
 from Color import Color

--- a/py/Interface.py
+++ b/py/Interface.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 

--- a/py/Process.py
+++ b/py/Process.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Configuration import Configuration
 from Color import Color

--- a/py/Scanner.py
+++ b/py/Scanner.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Airodump import Airodump
 from Color import Color

--- a/py/Target.py
+++ b/py/Target.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Color import Color
 

--- a/py/Wash.py
+++ b/py/Wash.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Process import Process
 

--- a/py/tests/test_Handshake.py
+++ b/py/tests/test_Handshake.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 import sys
 sys.path.insert(0, '..')

--- a/py/tests/test_Target.py
+++ b/py/tests/test_Target.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
+# -*- coding: utf-8 -*-
 
 from Airodump import Airodump
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-python -m unittest discover py
+python2.7 -m unittest discover py


### PR DESCRIPTION
Use the same python2.7 shebang in all py files as python defaults to python3 on some systems.