### PR TITLE
Add MAC Address Spoofing

### DIFF
--- a/py/Airmon.py
+++ b/py/Airmon.py
@@ -10,6 +10,9 @@ import re
 import os
 import signal
 
+from subprocess import Popen, call, PIPE
+
+
 class Airmon(object):
     ''' Wrapper around the 'airmon-ng' program '''
 
@@ -209,6 +212,16 @@ class Airmon(object):
             Color.pl('{+} {G}%s{W} is already in monitor mode' % iface.name)
         else:
             iface.name = Airmon.start(iface)
+        spoofing = Configuration.mac_spoof
+        if spoofing == True:
+            iface_mon = iface.name
+            DN = open(os.devnull, 'w')
+            proc = Popen(['ifconfig', iface_mon, 'down'], stdout=DN, stderr=DN)
+            proc.wait()
+            proc = Popen(['macchanger', '-r', iface_mon], stdout=DN, stderr=DN)
+            proc.wait()
+            proc = Popen(['ifconfig', iface_mon, 'up'], stdout=DN, stderr=DN)
+            proc.wait()
         return iface.name
 
 

--- a/py/Arguments.py
+++ b/py/Arguments.py
@@ -23,6 +23,11 @@ class Arguments(object):
             metavar='[interface]',
             type=str,
             help=Color.s('Wireless interface to use (default: {G}ask{W})'))
+        glob.add_argument('-m',
+            '--mac',
+            action='store_true',
+            dest='mac_spoof',
+            help=Color.s('Spoof random MAC address using macchanger (default: {G}off{W})'))
         glob.add_argument('-c',
             action='store',
             dest='channel',

--- a/py/AttackWEP.py
+++ b/py/AttackWEP.py
@@ -12,6 +12,9 @@ from CrackResultWEP import CrackResultWEP
 
 import time
 
+import os  # File management
+from subprocess import Popen, call, PIPE
+
 class AttackWEP(Attack):
     '''
         Contains logic for attacking a WEP-encrypted access point.
@@ -50,7 +53,17 @@ class AttackWEP(Attack):
                     if self.fake_auth():
                         # We successfully authenticated!
                         # Use our interface's MAC address for the attacks.
-                        client_mac = Interface.get_mac()
+                        DN = open(os.devnull, 'w')
+                        proc = Popen(['cat', '/sys/class/net/wlan0mon/address'], stdout=PIPE, stderr=DN)
+                        proc.wait()
+                        mac = ''
+                        first_line = proc.communicate()[0].split('\n')[0]
+                        for word in first_line.split(' '):
+                            if word != '': mac = word
+                        if mac.find('-') != -1: mac = mac.replace('-', ':')
+                        if len(mac) > 17: mac = mac[0:17]
+                        client_mac = mac
+
                     elif len(airodump_target.clients) == 0:
                         # There are no associated clients. Warn user.
                         Color.pl('{!} {O}there are no associated clients{W}')

--- a/py/Configuration.py
+++ b/py/Configuration.py
@@ -32,6 +32,7 @@ class Configuration(object):
         Configuration.target_essid = None # User-defined AP name
         Configuration.target_bssid = None # User-defined AP BSSID
         Configuration.five_ghz = False # Scan 5Ghz channels
+        Configuration.mac_spoof = False # Spoof mac
         Configuration.pillage = False # "All" mode to attack everything
 
         Configuration.encryption_filter = ['WEP', 'WPA', 'WPS']
@@ -104,6 +105,9 @@ class Configuration(object):
         from Arguments import Arguments
 
         args = Arguments(Configuration).args
+        if args.mac_spoof == True:
+            Configuration.mac_spoof = True
+            Color.pl('{+} {C}option:{W} Spoofing {G}MAC{W} Address')
         if args.channel:
             Configuration.target_channel = args.channel
             Color.pl('{+} {C}option:{W} scanning for targets on channel {G}%s{W}' % args.channel)


### PR DESCRIPTION
It uses macchanger and it only works if monitor mode is not enabled before running running Wifite.

Quick and dirty for personal use I don't doubt it could be done better but I saw some users requested the feature so here it is, as it works for me.

Look at what I did in the WEP fix commit but I would only pull the MAC Spoofing commit because the WEP fix uses a hard coded wlan0mon but the MAC Spoofing commit should be good also the WEP commit is untested and I reused some of your code from the old script.  I think it gives people a good idea that you can cat that file and get the mac in a nice format without all those 00's.