### PR TITLE
Add MAC Spoofing

### DIFF
--- a/py/Airmon.py
+++ b/py/Airmon.py
@@ -10,6 +10,9 @@ import re
 import os
 import signal
 
+from subprocess import Popen, call, PIPE
+
+
 class Airmon(object):
     ''' Wrapper around the 'airmon-ng' program '''
 
@@ -209,6 +212,16 @@ class Airmon(object):
             Color.pl('{+} {G}%s{W} is already in monitor mode' % iface.name)
         else:
             iface.name = Airmon.start(iface)
+        spoofing = Configuration.mac_spoof
+        if spoofing == True:
+            iface_mon = iface.name
+            DN = open(os.devnull, 'w')
+            proc = Popen(['ifconfig', iface_mon, 'down'], stdout=DN, stderr=DN)
+            proc.wait()
+            proc = Popen(['macchanger', '-r', iface_mon], stdout=DN, stderr=DN)
+            proc.wait()
+            proc = Popen(['ifconfig', iface_mon, 'up'], stdout=DN, stderr=DN)
+            proc.wait()
         return iface.name
 
 

--- a/py/Arguments.py
+++ b/py/Arguments.py
@@ -23,6 +23,11 @@ class Arguments(object):
             metavar='[interface]',
             type=str,
             help=Color.s('Wireless interface to use (default: {G}ask{W})'))
+        glob.add_argument('-m',
+            '--mac',
+            action='store_true',
+            dest='mac_spoof',
+            help=Color.s('Spoof random MAC address using macchanger (default: {G}off{W})'))
         glob.add_argument('-c',
             action='store',
             dest='channel',

--- a/py/Configuration.py
+++ b/py/Configuration.py
@@ -32,6 +32,7 @@ class Configuration(object):
         Configuration.target_essid = None # User-defined AP name
         Configuration.target_bssid = None # User-defined AP BSSID
         Configuration.five_ghz = False # Scan 5Ghz channels
+        Configuration.mac_spoof = False # Spoof mac
         Configuration.pillage = False # "All" mode to attack everything
 
         Configuration.encryption_filter = ['WEP', 'WPA', 'WPS']
@@ -104,6 +105,9 @@ class Configuration(object):
         from Arguments import Arguments
 
         args = Arguments(Configuration).args
+        if args.mac_spoof == True:
+            Configuration.mac_spoof = True
+            Color.pl('{+} {C}option:{W} Spoofing {G}MAC{W} Address')
         if args.channel:
             Configuration.target_channel = args.channel
             Color.pl('{+} {C}option:{W} scanning for targets on channel {G}%s{W}' % args.channel)


### PR DESCRIPTION
This PR should add MAC Spoofing to Wifite by issuing:
>python Wifite.py -m
or
python Wifite.py --mac

This works provided macchanger is installed on the machine and the WiFi interface must not be in monitor mode when starting the Wifite script or else it won't spoof the MAC.  In other words it spoofs the MAC when Wifite enables monitor mode.