### PR TITLE
Show exact number of connected clients

### DIFF
--- a/py/Target.py
+++ b/py/Target.py
@@ -128,10 +128,8 @@ class Target(object):
             wps = Color.s('{O} n/a')
 
         clients = '       '
-        if len(self.clients) == 1:
-            clients = Color.s('{G}client ')
-        elif len(self.clients) > 1:
-            clients = Color.s('{G}clients')
+        if len(self.clients) > 0:
+            clients = Color.s('{G}  ' + str(len(self.clients)))
 
         result = '%s  %s  %s  %s  %s  %s' % (essid, channel,
                                         encryption, power,


### PR DESCRIPTION
This is a small update which shows the exact number of clients connected to an AP. I like it more this way instead of `client` or `clients`. Feel free to reject this PR if does not suit you! No worries. :smile: 