### PR TITLE
scan exit unexpectly and no target show user

### DIFF
--- a/wifite/wifite.py
+++ b/wifite/wifite.py
@@ -20,7 +20,8 @@ from .model.handshake import Handshake
 import json
 import os
 import sys
-
+reload(sys)
+sys.setdefaultencoding('utf-8')
 class Wifite(object):
 
     def main(self):


### PR DESCRIPTION
**when i use the wifite 2.1.0 . I hava found it's exit unexpectly after catch package started some seconds . after take some time i have found when essid  in .cvs file include some unicode char it will happen so i  search a cure to make it goes well. i have test the cure it's work.**
trace bug like this 
  File "/usr/share/wifite/wifite/tools/airodump.py", line 146, in get_targets
    targets = Airodump.get_targets_from_csv(csv_filename)
  File "/usr/share/wifite/wifite/tools/airodump.py", line 205, in get_targets_from_csv
    for row in csv_reader:
UnicodeEncodeError: 'ascii' codec can't encode characters in position 137-140: ordinal not in range(128)