### PR TITLE
Old style exception won't work in Python 3

### DIFF
--- a/tests/test_Handshake.py
+++ b/tests/test_Handshake.py
@@ -23,7 +23,7 @@ class TestHandshake(unittest.TestCase):
         hs = Handshake(hs_file, bssid='A4:2B:8C:16:6B:3A')
         try:
             hs.analyze()
-        except Exception, e:
+        except Exception:
             fail()
 
     def testHandshakeTshark(self):


### PR DESCRIPTION
Old style exceptions were removed in Python 3.

flake8 testing of https://github.com/derv82/wifite2 on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/test_Handshake.py:26:25: E999 SyntaxError: invalid syntax
        except Exception, e:
                        ^
1     E999 SyntaxError: invalid syntax
1
```