### PR TITLE
Do not show handshake files that are in cracked.txt with a key (match on filename)

### DIFF
--- a/wifite/config.py
+++ b/wifite/config.py
@@ -81,6 +81,7 @@ class Configuration(object):
         cls.use_pmkid_only = False  # Only use PMKID Capture+Crack attack
 
         # Default dictionary for cracking
+        cls.cracked_file = 'cracked.txt'
         cls.wordlist = None
         wordlists = [
             './wordlist-top4800-probable.txt',  # Local file (ran from cloned repo)

--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from ..util.color import Color
+from ..config import Configuration
 
 import os
 import time
@@ -11,7 +12,7 @@ class CrackResult(object):
     ''' Abstract class containing results from a crack session '''
 
     # File to save cracks to, in PWD
-    cracked_file = 'cracked.txt'
+    cracked_file = Configuration.cracked_file
 
     def __init__(self):
         self.date = int(time.time())
@@ -55,8 +56,8 @@ class CrackResult(object):
             this_dict['date'] = entry.get('date')
             if entry == this_dict:
                 # Skip if we already saved this BSSID+ESSID+TYPE+KEY
-                Color.pl('{+} {C}%s{O} already exists in {G}cracked.txt{O}, skipping.' % (
-                    self.essid))
+                Color.pl('{+} {C}%s{O} already exists in {G}%s{O}, skipping.' % (
+                    self.essid, Configuration.cracked_file))
                 return
 
         saved_results.append(self.to_dict())
@@ -67,7 +68,7 @@ class CrackResult(object):
 
     @classmethod
     def display(cls):
-        ''' Show cracked targets from cracked.txt '''
+        ''' Show cracked targets from cracked file '''
         name = cls.cracked_file
         if not os.path.exists(name):
             Color.pl('{!} {O}file {C}%s{O} not found{W}' % name)

--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -20,8 +20,6 @@ import os
 
 # TODO: Bring back the 'print' option, for easy copy/pasting. Just one-liners people can paste into terminal.
 
-# TODO: Add an ability to select multiple dictionaries from a directory (the directory may possibly be an argument to the script --wordlist-dir).
-
 # TODO: --no-crack option while attacking targets (implies user will run --crack later)
 
 class CrackHelper:

--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -52,7 +52,7 @@ class CrackHelper:
             return
 
         hs_to_crack = cls.get_user_selection(handshakes)
-        any_pmkid = any([hs['type'] == 'PMKID' for hs in hs_to_crack])
+        all_pmkid = all([hs['type'] == 'PMKID' for hs in hs_to_crack])
 
         # Tools for cracking & their dependencies.
         available_tools = {
@@ -78,7 +78,7 @@ class CrackHelper:
                 dep_list = ', '.join([dep.dependency_name for dep in deps])
                 Color.pl('     {R}* {R}%s {W}({O}%s{W})' % (tool, dep_list))
 
-        if any_pmkid:
+        if all_pmkid:
             Color.pl('{!} {O}Note: PMKID hashes will be cracked using {C}hashcat{W}')
             tool_name = 'hashcat'
         else:
@@ -91,6 +91,11 @@ class CrackHelper:
 
         try:
             for hs in hs_to_crack:
+                if tool_name != 'hashcat' and hs['type'] == 'PMKID':
+                    if 'hashcat' in missing_tools:
+                        Color.pl('{!} {O}Hashcat is missing, therefore we cannot crack PMKID hash{W}')
+                    else:
+                        cls.crack(hs, 'hashcat')
                 cls.crack(hs, tool_name)
         except KeyboardInterrupt:
             Color.pl('\n{!} {O}Interrupted{W}')
@@ -106,7 +111,7 @@ class CrackHelper:
         for result in json:
             for k in result.keys():
                 v = result[k]
-                if 'file' in k and v.split('/')[1] == file:
+                if 'file' in k and os.path.basename(v) == file:
                     return True
         return False
 


### PR DESCRIPTION
Additional changes:
* Make cracked.txt a configurable variable
* Don't ask user for a crack-tool when attacking PMKIDs only
* Few minor cleanups