### PR TITLE
Bugfix PRs - Two bugs fixed

### DIFF
--- a/wifite/model/handshake.py
+++ b/wifite/model/handshake.py
@@ -121,7 +121,7 @@ class Handshake(object):
         command = 'echo "" | aircrack-ng -a 2 -w - -b %s "%s"' % (self.bssid, self.capfile)
         (stdout, stderr) = Process.call(command)
 
-        if 'passphrase not in dictionary' in stdout.lower():
+        if 'passphrase not in dictionary' in stdout.lower() or 'key not found' in stdout.lower():
             return [(self.bssid, None)]
         else:
             return []

--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -30,6 +30,14 @@ class CrackHelper:
         'PMKID': 'PMKID Hash'
     }
 
+    # Tools for cracking & their dependencies.
+    possible_tools = [
+        ('aircrack', [Aircrack]),
+        ('hashcat', [Hashcat, HcxPcapTool]),
+        ('john', [John, HcxPcapTool]),
+        ('cowpatty', [Cowpatty])
+    ]
+
     @classmethod
     def run(cls):
         Configuration.initialize(False)
@@ -52,23 +60,18 @@ class CrackHelper:
         hs_to_crack = cls.get_user_selection(handshakes)
         all_pmkid = all([hs['type'] == 'PMKID' for hs in hs_to_crack])
 
-        # Tools for cracking & their dependencies.
-        available_tools = {
-            'aircrack': [Aircrack],
-            'hashcat':  [Hashcat, HcxPcapTool],
-            'john':     [John, HcxPcapTool],
-            'cowpatty': [Cowpatty]
-        }
         # Identify missing tools
         missing_tools = []
-        for tool, dependencies in available_tools.items():
+        available_tools = []
+        for tool, dependencies in cls.possible_tools:
             missing = [
                 dep for dep in dependencies
                 if not Process.exists(dep.dependency_name)
             ]
             if len(missing) > 0:
-                available_tools.pop(tool)
-                missing_tools.append( (tool, missing) )
+                missing_tools.append((tool, missing))
+            else:
+                available_tools.append(tool)
 
         if len(missing_tools) > 0:
             Color.pl('\n{!} {O}Unavailable tools (install to enable):{W}')
@@ -81,7 +84,7 @@ class CrackHelper:
             tool_name = 'hashcat'
         else:
             Color.p('\n{+} Enter the {C}cracking tool{W} to use ({C}%s{W}): {G}' % (
-                '{W}, {C}'.join(available_tools.keys())))
+                '{W}, {C}'.join(available_tools)))
             tool_name = raw_input()
             if tool_name not in available_tools:
                 Color.pl('{!} {R}"%s"{O} tool not found, defaulting to {C}aircrack{W}' % tool_name)


### PR DESCRIPTION
First commit fixes the issue detailed in #157 . Wifite would crash
if ran using python3 and the parameter --crack if a dependency
was missing, just after selecting a target.
This was caused by popping from a dictionary while iterating on
it, an operation forbidden in python3. Issue described in #157