### PR TITLE
attack/pmkid: removed hashcat dependency for PMKID capture

### DIFF
--- a/wifite/attack/all.py
+++ b/wifite/attack/all.py
@@ -146,4 +146,3 @@ class AttackAll(object):
             return False  # Exit
         else:
             return True  # Continue
-

--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -65,7 +65,6 @@ class AttackPMKID(Attack):
         from ..util.process import Process
         # Check that we have all hashcat programs
         dependencies = [
-            Hashcat.dependency_name,
             HcxDumpTool.dependency_name,
             HcxPcapTool.dependency_name
         ]
@@ -91,12 +90,17 @@ class AttackPMKID(Attack):
             return False  # No hash found.
 
         # Crack it.
-        try:
-            self.success = self.crack_pmkid_file(pmkid_file)
-        except KeyboardInterrupt:
-            Color.pl('\n{!} {R}Failed to crack PMKID: {O}Cracking interrupted by user{W}')
+        if Process.exists(Hashcat.dependency_name):
+            try:
+                self.success = self.crack_pmkid_file(pmkid_file)
+            except KeyboardInterrupt:
+                Color.pl('\n{!} {R}Failed to crack PMKID: {O}Cracking interrupted by user{W}')
+                self.success = False
+                return True
+        else:
             self.success = False
-            return False
+            Color.pl('\n {O}[{R}!{O}] Note: PMKID attacks are not possible because you do not have {C}%s{O}.{W}'
+                     % Hashcat.dependency_name)
 
         return True  # Even if we don't crack it, capturing a PMKID is 'successful'
 
@@ -210,4 +214,3 @@ class AttackPMKID(Attack):
             pmkid_handle.write('\n')
 
         return pmkid_file
-


### PR DESCRIPTION
Removed hashcat dependency from dependencies in attack/pmkid
and added as condition for cracking as asked in the #149  issue.
Printing a note for hashcat missing.