### PR TITLE
Removed 88XXau support as airmon-ng now got it

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -59,10 +59,10 @@ class Arguments(object):
             action='store',
             dest='channel',
             metavar='[channel]',
-            type=int,
-            help=Color.s('Wireless channel to scan (default: {G}all 2Ghz channels{W})'))
+            help=Color.s('Wireless channel to scan e.g. {C}1,3-6{W} ' +
+                '(default: {G}all 2Ghz channels{W})'))
         glob.add_argument('--channel', help=argparse.SUPPRESS, action='store',
-                dest='channel', type=int)
+            dest='channel')
 
         glob.add_argument('-5',
             '--5ghz',

--- a/wifite/args.py
+++ b/wifite/args.py
@@ -115,14 +115,15 @@ class Arguments(object):
                 dest='target_essid', type=str)
 
         glob.add_argument('-E',
-            action='store',
-            dest='ignore_essid',
+            action='append',
+            dest='ignore_essids',
             metavar='[text]',
             type=str,
             default=None,
-            help=self._verbose('Hides targets with ESSIDs that match the given text'))
-        glob.add_argument('--ignore-essid', help=argparse.SUPPRESS, action='store',
-                dest='ignore_essid', type=str)
+            help=self._verbose('Hides targets with ESSIDs that match the given text. '
+                               'Can be used more than once.'))
+        glob.add_argument('--ignore-essid', help=argparse.SUPPRESS, action='append',
+                dest='ignore_essids', type=str)
 
         glob.add_argument('--clients-only',
             action='store_true',

--- a/wifite/args.py
+++ b/wifite/args.py
@@ -433,6 +433,11 @@ class Arguments(object):
                          dest='use_pmkid_only',
                          help=Color.s('{O}Only{W} use {C}PMKID capture{W}, avoids other WPS & ' +
                                       'WPA attacks (default: {G}off{W})'))
+        pmkid.add_argument('--no-pmkid',
+                         action='store_true',
+                         dest='dont_use_pmkid',
+                         help=Color.s('{O}Don\'t{W} use {C}PMKID capture{W} ' +
+                                      '(default: {G}off{W})'))
         # Alias
         pmkid.add_argument('-pmkid', help=argparse.SUPPRESS, action='store_true', dest='use_pmkid_only')
 

--- a/wifite/attack/all.py
+++ b/wifite/attack/all.py
@@ -44,6 +44,9 @@ class AttackAll(object):
         Attacks a single `target` (wifite.model.target).
         Returns: True if attacks should continue, False otherwise.
         '''
+        if 'MGT' in target.authentication:
+            Color.pl("\n{!}{O}Skipping. Target is using {C}WPA-Enterprise {O}and can not be cracked.")
+            return True
 
         attacks = []
 

--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -62,6 +62,12 @@ class AttackPMKID(Attack):
         Returns:
             True if handshake is captured. False otherwise.
         '''
+
+        # Skip if user doesn't want to run PMKID attack 
+        if Configuration.dont_use_pmkid:
+            self.success = False
+            return False
+
         from ..util.process import Process
         # Check that we have all hashcat programs
         dependencies = [

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 
 from .util.color import Color
 from .tools.macchanger import Macchanger
@@ -179,6 +180,10 @@ class Configuration(object):
                     'when scanning & attacking')
 
         if args.channel:
+            chn_arg_re = re.compile("^[0-9]+((,[0-9]+)|(-[0-9]+,[0-9]+))*(-[0-9]+)?$")
+            if not chn_arg_re.match(args.channel):
+                raise ValueError("Invalid channel! The format must be 1,3-6,9")
+
             cls.target_channel = args.channel
             Color.pl('{+} {C}option:{W} scanning for targets on channel ' +
                     '{G}%s{W}' % args.channel)

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -41,7 +41,7 @@ class Configuration(object):
         cls.target_channel = None # User-defined channel to scan
         cls.target_essid = None # User-defined AP name
         cls.target_bssid = None # User-defined AP BSSID
-        cls.ignore_essid = None # ESSIDs to ignore
+        cls.ignore_essids = None # ESSIDs to ignore
         cls.clients_only = False # Only show targets that have associated clients
         cls.five_ghz = False # Scan 5Ghz channels
         cls.show_bssids = False # Show BSSIDs in targets list
@@ -215,10 +215,10 @@ class Configuration(object):
             cls.target_essid = args.target_essid
             Color.pl('{+} {C}option:{W} targeting ESSID {G}%s{W}' % args.target_essid)
 
-        if args.ignore_essid is not None:
-            cls.ignore_essid = args.ignore_essid
-            Color.pl('{+} {C}option:{W} {O}ignoring ESSIDs that include {R}%s{W}' % (
-                args.ignore_essid))
+        if args.ignore_essids is not None:
+            cls.ignore_essids = args.ignore_essids
+            Color.pl('{+} {C}option: {O}ignoring ESSID(s): {R}%s{W}' %
+                     ', '.join(args.ignore_essids))
 
         if args.clients_only == True:
             cls.clients_only = True

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -82,6 +82,7 @@ class Configuration(object):
         # PMKID variables
         cls.use_pmkid_only = False  # Only use PMKID Capture+Crack attack
         cls.pmkid_timeout = 30  # Time to wait for PMKID capture
+        cls.dont_use_pmkid = False # Don't use PMKID attack
 
         # Default dictionary for cracking
         cls.cracked_file = 'cracked.txt'
@@ -168,6 +169,9 @@ class Configuration(object):
         if cls.use_pmkid_only and cls.wps_only:
             Color.pl('{!} {R}Bad Configuration:{O} --pmkid and --wps-only are not compatible')
             raise RuntimeError('Unable to attack networks: --pmkid and --wps-only are not compatible together')
+        if cls.use_pmkid_only and cls.dont_use_pmkid:
+            Color.pl('{!} {R}Bad Configuration:{O} --pmkid and --no-pmkid are not compatible')
+            raise RuntimeError('Unable to attack networks: --pmkid and --no-pmkid are not compatible together')
 
 
     @classmethod
@@ -392,6 +396,10 @@ class Configuration(object):
         if args.pmkid_timeout:
             cls.pmkid_timeout = args.pmkid_timeout
             Color.pl('{+} {C}option:{W} will wait {G}%d seconds{W} during {C}PMKID{W} capture' % args.pmkid_timeout)
+
+        if args.dont_use_pmkid:
+            cls.dont_use_pmkid = True
+            Color.pl('{+} {C}option:{W} will NOT use {C}PMKID{W} attack on WPA networks')
 
     @classmethod
     def parse_encryption(cls):

--- a/wifite/model/target.py
+++ b/wifite/model/target.py
@@ -37,10 +37,10 @@ class Target(object):
                     13 ESSID          (HOME-ABCD)
                     14 Key            ()
         '''
-        self.bssid      =     fields[0].strip()
-        self.channel    =     fields[3].strip()
-
-        self.encryption =     fields[5].strip()
+        self.bssid          =     fields[0].strip()
+        self.channel        =     fields[3].strip()
+        self.encryption     =     fields[5].strip()
+        self.authentication =     fields[7].strip()
         if 'WPA' in self.encryption:
             self.encryption = 'WPA'
         elif 'WEP' in self.encryption:
@@ -122,11 +122,16 @@ class Target(object):
             channel_color = '{C}'
         channel = Color.s('%s%s' % (channel_color, str(self.channel).rjust(3)))
 
-        encryption = self.encryption.rjust(4)
+        encryption = self.encryption.rjust(3)
         if 'WEP' in encryption:
             encryption = Color.s('{G}%s' % encryption)
         elif 'WPA' in encryption:
-            encryption = Color.s('{O}%s' % encryption)
+            if 'PSK' in self.authentication:
+                encryption = Color.s('{O}%s-P' % encryption)
+            elif 'MGT' in self.authentication:
+                encryption = Color.s('{R}%s-E' % encryption)
+            else:
+                encryption = Color.s('{O}%s  ' % encryption)
 
         power = '%sdb' % str(self.power).rjust(3)
         if self.power > 50:

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -271,7 +271,9 @@ class Airodump(Dependency):
         essid = Configuration.target_essid
         i = 0
         while i < len(result):
-            if result[i].essid is not None and Configuration.ignore_essid is not None and Configuration.ignore_essid.lower() in result[i].essid.lower():
+            if result[i].essid is not None and\
+                    Configuration.ignore_essids is not None and\
+                    result[i].essid in Configuration.ignore_essids:
                 result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -277,7 +277,7 @@ class Airodump(Dependency):
                 result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)
-            elif essid and result[i].essid and result[i].essid.lower() != essid.lower():
+            elif essid and result[i].essid and result[i].essid != essid:
                 result.pop(i)
             else:
                 i += 1

--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -30,6 +30,14 @@ class CrackHelper:
         'PMKID': 'PMKID Hash'
     }
 
+    # Tools for cracking & their dependencies.
+    possible_tools = [
+        ('aircrack', [Aircrack]),
+        ('hashcat', [Hashcat, HcxPcapTool]),
+        ('john', [John, HcxPcapTool]),
+        ('cowpatty', [Cowpatty])
+    ]
+
     @classmethod
     def run(cls):
         Configuration.initialize(False)
@@ -52,23 +60,18 @@ class CrackHelper:
         hs_to_crack = cls.get_user_selection(handshakes)
         all_pmkid = all([hs['type'] == 'PMKID' for hs in hs_to_crack])
 
-        # Tools for cracking & their dependencies.
-        available_tools = {
-            'aircrack': [Aircrack],
-            'hashcat':  [Hashcat, HcxPcapTool],
-            'john':     [John, HcxPcapTool],
-            'cowpatty': [Cowpatty]
-        }
         # Identify missing tools
         missing_tools = []
-        for tool, dependencies in available_tools.items():
+        available_tools = []
+        for tool, dependencies in cls.possible_tools:
             missing = [
                 dep for dep in dependencies
                 if not Process.exists(dep.dependency_name)
             ]
             if len(missing) > 0:
-                available_tools.pop(tool)
-                missing_tools.append( (tool, missing) )
+                missing_tools.append((tool, missing))
+            else:
+                available_tools.append(tool)
 
         if len(missing_tools) > 0:
             Color.pl('\n{!} {O}Unavailable tools (install to enable):{W}')
@@ -81,7 +84,7 @@ class CrackHelper:
             tool_name = 'hashcat'
         else:
             Color.p('\n{+} Enter the {C}cracking tool{W} to use ({C}%s{W}): {G}' % (
-                '{W}, {C}'.join(available_tools.keys())))
+                '{W}, {C}'.join(available_tools)))
             tool_name = raw_input()
             if tool_name not in available_tools:
                 Color.pl('{!} {R}"%s"{O} tool not found, defaulting to {C}aircrack{W}' % tool_name)

--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -93,7 +93,7 @@ class Scanner(object):
             if bssid and target.bssid and bssid.lower() == target.bssid.lower():
                 self.target = target
                 break
-            if essid and target.essid and essid.lower() == target.essid.lower():
+            if essid and target.essid and essid == target.essid:
                 self.target = target
                 break
 

--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -138,14 +138,14 @@ class Scanner(object):
         Color.p('                      ESSID')
         if Configuration.show_bssids:
             Color.p('              BSSID')
-        Color.pl('   CH  ENCR  POWER  WPS?  CLIENT')
+        Color.pl('   CH  ENCR   POWER  WPS?  CLIENT')
 
         # Second row: separator
         Color.p('   ---')
         Color.p('  -------------------------')
         if Configuration.show_bssids:
             Color.p('  -----------------')
-        Color.pl('  ---  ----  -----  ----  ------{W}')
+        Color.pl('  ---  -----  -----  ----  ------{W}')
 
         # Remaining rows: targets
         for idx, target in enumerate(self.targets, start=1):
@@ -213,7 +213,7 @@ class Scanner(object):
                 break
             if '-' in choice:
                 # User selected a range
-                (lower,upper) = [int(x) - 1 for x in choice.split('-')]
+                (lower, upper) = [int(x) - 1 for x in choice.split('-')]
                 for i in xrange(lower, min(len(self.targets), upper + 1)):
                     chosen_targets.append(self.targets[i])
             elif choice.isdigit():


### PR DESCRIPTION
* aircrack-ng suite has added 88XXau (rtl8812au stack) support into airmon-ng, a much easier way to get more tools supported to it. Therefor, the support is not needed anymore.