### PR TITLE
Ignore multiple ESSIDs with -E

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -115,14 +115,15 @@ class Arguments(object):
                 dest='target_essid', type=str)
 
         glob.add_argument('-E',
-            action='store',
-            dest='ignore_essid',
+            action='append',
+            dest='ignore_essids',
             metavar='[text]',
             type=str,
             default=None,
-            help=self._verbose('Hides targets with ESSIDs that match the given text'))
-        glob.add_argument('--ignore-essid', help=argparse.SUPPRESS, action='store',
-                dest='ignore_essid', type=str)
+            help=self._verbose('Hides targets with ESSIDs that match the given text. '
+                               'Can be used more than once.'))
+        glob.add_argument('--ignore-essid', help=argparse.SUPPRESS, action='append',
+                dest='ignore_essids', type=str)
 
         glob.add_argument('--clients-only',
             action='store_true',

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -41,7 +41,7 @@ class Configuration(object):
         cls.target_channel = None # User-defined channel to scan
         cls.target_essid = None # User-defined AP name
         cls.target_bssid = None # User-defined AP BSSID
-        cls.ignore_essid = None # ESSIDs to ignore
+        cls.ignore_essids = None # ESSIDs to ignore
         cls.clients_only = False # Only show targets that have associated clients
         cls.five_ghz = False # Scan 5Ghz channels
         cls.show_bssids = False # Show BSSIDs in targets list
@@ -215,10 +215,10 @@ class Configuration(object):
             cls.target_essid = args.target_essid
             Color.pl('{+} {C}option:{W} targeting ESSID {G}%s{W}' % args.target_essid)
 
-        if args.ignore_essid is not None:
-            cls.ignore_essid = args.ignore_essid
-            Color.pl('{+} {C}option:{W} {O}ignoring ESSIDs that include {R}%s{W}' % (
-                args.ignore_essid))
+        if args.ignore_essids is not None:
+            cls.ignore_essids = args.ignore_essids
+            Color.pl('{+} {C}option: {O}ignoring ESSID(s): {R}%s{W}' %
+                     ', '.join(args.ignore_essids))
 
         if args.clients_only == True:
             cls.clients_only = True

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -271,7 +271,9 @@ class Airodump(Dependency):
         essid = Configuration.target_essid
         i = 0
         while i < len(result):
-            if result[i].essid is not None and Configuration.ignore_essid is not None and Configuration.ignore_essid.lower() in result[i].essid.lower():
+            if result[i].essid is not None and\
+                    Configuration.ignore_essids is not None and\
+                    result[i].essid in Configuration.ignore_essids:
                 result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -277,7 +277,7 @@ class Airodump(Dependency):
                 result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)
-            elif essid and result[i].essid and result[i].essid.lower() != essid.lower():
+            elif essid and result[i].essid and result[i].essid != essid:
                 result.pop(i)
             else:
                 i += 1

--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -93,7 +93,7 @@ class Scanner(object):
             if bssid and target.bssid and bssid.lower() == target.bssid.lower():
                 self.target = target
                 break
-            if essid and target.essid and essid.lower() == target.essid.lower():
+            if essid and target.essid and essid == target.essid:
                 self.target = target
                 break
 


### PR DESCRIPTION
Currently there is no way to specify multiple ESSIDs to ignore as described in issue #148. Instead of a simple string now the ignore_essid variable is a list of strings which we check inside the Airodump.filter_targets method. The -E <ESSID> paramater needs to be specified for each ignored AP.

I've also made the check case sensitive as I believe it allows better control. After all the SSID is case sensitive itself, there is little reason to make the check case insensitive, besides easier typing. I've also made attacking one target based on the ESSID case sensitive, for the same reasons. I can remove these changes need be.
