### PR TITLE
Added blank PIN attack

### DIFF
--- a/wifite/attack/all.py
+++ b/wifite/attack/all.py
@@ -64,6 +64,10 @@ class AttackAll(object):
                     if Configuration.wps_pixie:
                         attacks.append(AttackWPS(target, pixie_dust=True))
 
+                    # Null PIN zero-day attack
+                    if Configuration.wps_pin:
+                        attacks.append(AttackWPS(target, pixie_dust=False, null_pin=True))
+
                     # PIN attack
                     if Configuration.wps_pin:
                         attacks.append(AttackWPS(target, pixie_dust=False))

--- a/wifite/attack/wps.py
+++ b/wifite/attack/wps.py
@@ -14,11 +14,12 @@ class AttackWPS(Attack):
     def can_attack_wps():
         return Reaver.exists() or Bully.exists()
 
-    def __init__(self, target, pixie_dust=False):
+    def __init__(self, target, pixie_dust=False, null_pin=False):
         super(AttackWPS, self).__init__(target)
         self.success = False
         self.crack_result = None
         self.pixie_dust = pixie_dust
+        self.null_pin = null_pin
 
     def run(self):
         ''' Run all WPS-related attacks '''
@@ -78,7 +79,7 @@ class AttackWPS(Attack):
 
 
     def run_reaver(self):
-        reaver = Reaver(self.target, pixie_dust=self.pixie_dust)
+        reaver = Reaver(self.target, pixie_dust=self.pixie_dust, null_pin=self.null_pin)
         reaver.run()
         self.crack_result = reaver.crack_result
         self.success = self.crack_result is not None


### PR DESCRIPTION
Implemented blank PIN attack regarding issue #172.
In the same way that Pixie Dust attack needs just 1 PIN, the blank PIN attack uses the same timeout as Pixie Dust, which is configurable via parameters, but doesn't require Pixie Dust option enabled in order to work, just WPS PIN option.

