### PR TITLE
Fix wifite crack mode crash on python3

### DIFF
--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -61,7 +61,7 @@ class CrackHelper:
         }
         # Identify missing tools
         missing_tools = []
-        for tool, dependencies in available_tools.items():
+        for tool, dependencies in list(available_tools.items()):
             missing = [
                 dep for dep in dependencies
                 if not Process.exists(dep.dependency_name)


### PR DESCRIPTION
Fixes #157

On Python3 method `dict.items` returns iterator object instead of copy of KV pairs. For this reason iteration fails if dictionary modified inside loop. Actual pull request fixes mentioned issue.