### PR TITLE
PEP8: Don't directly compare types, use isinstance()

### DIFF
--- a/wifite/tools/ifconfig.py
+++ b/wifite/tools/ifconfig.py
@@ -16,9 +16,9 @@ class Ifconfig(Dependency):
         from ..util.process import Process
 
         command = ['ifconfig', interface]
-        if type(args) is list:
+        if isinstance(args, list):
             command.extend(args)
-        elif type(args) is 'str':
+        elif isinstance(args, str):
             command.append(args)
         command.append('up')
 


### PR DESCRIPTION
```
>>> type('str') is 'str'
False
>>> type('str') is str
True
>>> isinstance('str', str)
True
```
https://pep8.org/#programming-recommendations

[flake8](http://flake8.pycqa.org) testing of https://github.com/derv82/wifite2 on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./tests/test_Handshake.py:28:13: F821 undefined name 'fail'
            fail()
            ^
./wifite/tools/ifconfig.py:21:14: F632 use ==/!= to compare str, bytes, and int literals
        elif type(args) is 'str':
             ^
1     F632 use ==/!= to compare str, bytes, and int literals
1     F821 undefined name 'fail'
2
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.
