### PR TITLE
ifconfig.py: suppress warning on apt install

### DIFF
--- a/wifite/tools/ifconfig.py
+++ b/wifite/tools/ifconfig.py
@@ -16,9 +16,9 @@ class Ifconfig(Dependency):
         from ..util.process import Process
 
         command = ['ifconfig', interface]
-        if type(args) is list:
+        if type(args) == list:
             command.extend(args)
-        elif type(args) is 'str':
+        elif type(args) == 'str':
             command.append(args)
         command.append('up')
 
@@ -58,4 +58,3 @@ class Ifconfig(Dependency):
             return match.group(1)
 
         raise Exception('Could not find the mac address for %s' % interface)
-


### PR DESCRIPTION
When installing with apt you have a warning:
/usr/lib/python3/dist-packages/wifite/tools/ifconfig.py:21: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif type(args) is 'str':

It is now common (see https://github.com/gnuradio/gnuradio/pull/3066)