### PR TITLE
PEP8: Use isinstance() instead of comparing types

### DIFF
--- a/wifite/tools/ifconfig.py
+++ b/wifite/tools/ifconfig.py
@@ -16,9 +16,9 @@ class Ifconfig(Dependency):
         from ..util.process import Process
 
         command = ['ifconfig', interface]
-        if type(args) is list:
+        if isinstance(args, list):
             command.extend(args)
-        elif type(args) is 'str':
+        elif isinstance(args, str):
             command.append(args)
         command.append('up')
 


### PR DESCRIPTION
```
>>> type('str') is 'str'
False
>>> type('str') is str
True
>>> isinstance('str', str)
True
```