### PR TITLE
[Fixed] Corrected Network-Manager issue

### DIFF
--- a/wifite/tools/airmon.py
+++ b/wifite/tools/airmon.py
@@ -382,7 +382,7 @@ class Airmon(Dependency):
         Color.p('{!} {O}restarting {R}NetworkManager{O}...')
 
         if Process.exists('service'):
-            cmd = 'service network-manager start'
+            cmd = 'service NetworkManager start'
             proc = Process(cmd)
             (out, err) = proc.get_output()
             if proc.poll() != 0:


### PR DESCRIPTION
It was written in the cmd <b> "service network-manager start" </b> which is the wrong syntax.
The correct syntax is : 
```
service NetworkManager start/restart/stop
```
