### PR TITLE
Update result.py

### DIFF
--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -133,6 +133,7 @@ class CrackResult(object):
         elif json['type'] == 'WPS':
             from .wps_result import CrackResultWPS
             result = CrackResultWPS(json['bssid'],
+                                    json['channel'],
                                     json['essid'],
                                     json['pin'],
                                     json['psk'])


### PR DESCRIPTION
CrackResultWPS.init() missing 1 required positional argument {channel}!!!

Attention, this error prevents viewing hacked networks.