### PR TITLE
Allow `airodump-ng` to exit & get reaped

### DIFF
--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -69,6 +69,7 @@ class Airodump(Dependency):
         command = [
             'airodump-ng',
             self.interface,
+            '--background', '1', # Force "background mode" since we rely on csv instead of stdout
             '-a', # Only show associated clients
             '-w', self.csv_file_prefix, # Output file prefix
             '--write-interval', '1' # Write every second


### PR DESCRIPTION
Attempts to address #335.

It seems like `airodump-ng` was not exiting in a timely manner. One way that this manifests itself, is as the little 2 second "hickup" that occurs after the user sends _Ctrl-c_ to stop scanning: if you crank verbosity up to at least 2 (`-vv`), you can clearly see that the process handling goes a little bit something like this when the scanning finishes:

```
 [?]  sending interrupt to PID 661927 (airodump-ng wlan0 -a -w /tmp/wifiteii2to_hi/airodump --write-interval 1 -c 1 --wps --output-format pcap,csv)

 [?]  Waited > 2.00 seconds for process to die, killing it
```

but the process never does exit - it is waiting for something - buffered output to be read, or something along those lines.

Seems like `airodump-ng` has a completely mute background-mode exactly for this purpose - so let's ensure it is used.

